### PR TITLE
fix: update broken links to Noir installation guide

### DIFF
--- a/foundry-voting/README.md
+++ b/foundry-voting/README.md
@@ -4,7 +4,7 @@
 
 This example project shows how to create a simple zk voting circuit in Noir with a corresponding Solidity contract to track eligible voters, proposals and votes.
 
-This example was last tested with Noir version 0.10.3. You can install it with [noirup](https://noir-lang.org/getting_started/nargo_installation#option-1-noirup) using
+This example was last tested with Noir version 0.10.3. You can install it with [noirup](https://noir-lang.org/docs/getting_started/installation/#installing-noirup) using
 
 ```bash
 noirup -v 0.10.3

--- a/recursion/README.md
+++ b/recursion/README.md
@@ -10,7 +10,7 @@ Why is this useful? In this example, it doesn't do much. But you could verify tw
 
 ## Getting Started
 
-1. [Install nargo](https://noir-lang.org/getting_started/nargo_installation#option-1-noirup) version 0.17.0 with `noirup -v 0.17.0`
+1. [Install nargo](https://noir-lang.org/docs/getting_started/installation/#installing-noirup) version 0.17.0 with `noirup -v 0.17.0`
 2. Install dependencies by running `yarn`
 3. Compile the project with `yarn compile`
 4. Run `yarn dev`

--- a/stealthdrop/README.md
+++ b/stealthdrop/README.md
@@ -6,7 +6,7 @@ This is a much faster version of Stealthdrop, built with Noir.
 
 ## Getting Started
 
-1. [Install nargo](https://noir-lang.org/getting_started/nargo_installation#option-1-noirup) version 0.17.0 with `noirup -v 0.17.0`
+1. [Install nargo](https://noir-lang.org/docs/getting_started/installation/#installing-noirup) version 0.17.0 with `noirup -v 0.17.0`
 2. Rename `env.examples` to `.env`, you can set up a number of things there but it contains sensible defaults
 3. Install dependencies by running `yarn`
 4. Compile the project with `yarn compile`


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

Update broken links to Noir docs (installation guide).

## Problem\*

I've found several broken link to Noir Docs. This PR fixes the issues.

## Summary\*
...

## Additional Context

...

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
