### PR TITLE
Fix Incorrect Test File Link in Recursion README.md

### DIFF
--- a/recursion/README.md
+++ b/recursion/README.md
@@ -18,4 +18,4 @@ You could also avoid verifying stuff on-chain for turn-based games, for example.
 
 ## Testing
 
-To run the [test file](./test/index.ts), try `yarn test`
+To run the [test file](./packages/hardhat/test/index.test.ts), try `yarn test`


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

The test file link in the `README.md` of the `recursion` folder within the `noir-examples` repository was incorrect, pointing to a non-existing path. This made it difficult for users to locate and run the test file as instructed.

## Summary\*

This Pull Request updates the `README.md` file in the `recursion` folder to correct the path to the test file. The link has been updated from `./test/index.ts` to `./packages/hardhat/test/index.test.ts`, reflecting the actual location of the test file within the repository structure.

## Additional Context

This change makes sure that contributors and users can correctly access and run the test file as described in the `README.md`, improving the developer experience.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
