### PR TITLE
Fix Broken Badge URL

### DIFF
--- a/foundry-voting/README.md
+++ b/foundry-voting/README.md
@@ -1,6 +1,6 @@
 # zk Voting with Foundry
 
-[![Run Tests on PR](https://github.com/noir-lang/noir-starter/actions/workflows/foundry-voting.yml/badge.svg)](https://github.com/noir-lang/noir-starter/actions/workflows/foundry-voting.yml)
+[![Run Tests on PR]()](https://github.com/noir-lang/noir-starter/actions/workflows/foundry-voting.yml)
 
 This example project shows how to create a simple zk voting circuit in Noir with a corresponding Solidity contract to track eligible voters, proposals and votes.
 


### PR DESCRIPTION


## Changes
- File modified: `foundry-voting/README.md`
- Current badge URL (broken):
[![Run Tests on PR](https://github.com/noir-lang/noir-starter/actions/workflows/foundry-voting.yml/badge.svg)]

## Request
Please provide the correct workflow URL for the badge to properly display the build status.
