### PR TITLE
Fix incorrect implementation of `fail` function

### DIFF
--- a/foundry-voting/lib/forge-std/src/StdAssertions.sol
+++ b/foundry-voting/lib/forge-std/src/StdAssertions.sol
@@ -14,7 +14,7 @@ abstract contract StdAssertions is DSTest {
 
     function fail(string memory err) internal virtual {
         emit log_named_string("Error", err);
-        fail();
+        super.fail();
     }
 
     function assertFalse(bool data) internal virtual {


### PR DESCRIPTION
# Description

In the current implementation, the `fail` function calls itself without a termination condition, leading to infinite recursion. Instead of invoking the `fail` function from the parent `DSTest` contract, the current implementation loops on itself, making it impossible to properly execute tests and handle errors.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
