### PR TITLE
update .cursorignore and add setup script

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,8 +1,6 @@
 **/dist/
 **/build/
 **/out/
-**/target/
-**/node_modules/
 **/.env*
 **/coverage/
 **/test-results/

--- a/README.md
+++ b/README.md
@@ -18,3 +18,16 @@ Need help? Join the [Noir Discord](https://discord.gg/JtqzkdeQ6G) or reach out o
 ## Contributing
 
 We welcome contributions! Check out the [contributing guidelines](./CONTRIBUTING.md) for more info.
+
+## OpenAI Codex
+
+If using [OpenAI Codex](https://chatgpt.com/codex/) add the following to your environment, so that the agents can run `nargo` and `bb` commands.
+
+Make it so that it can run the startup script.
+
+```bash
+chmod +x ./scripts/setup-all.sh
+./scripts/setup-all.sh
+```
+
+And turn on internet access. Giving access to "Common Dependencies" and this specific url should be sufficient, `aztec-ignition.s3.amazonaws.com`.

--- a/scripts/setup-all.sh
+++ b/scripts/setup-all.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# This script was created to make it easy to set up the environment for OpenAI Codex.
+# It automates the installation and setup of all necessary dependencies for the
+# noir-examples repository, including Noir, Barretenberg, Node.js packages, and Rust projects.
+
 set -euo pipefail
 
 # Install Noir (noirup) and Barretenberg (bbup)

--- a/scripts/setup-all.sh
+++ b/scripts/setup-all.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Noir (noirup) and Barretenberg (bbup)
+echo "Installing latest Noir..."
+curl -sSL https://raw.githubusercontent.com/noir-lang/noirup/refs/heads/main/install | bash
+export PATH="$HOME/.nargo/bin:$PATH"
+noirup
+
+echo "Installing latest Barretenberg..."
+curl -sSL https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/master/barretenberg/bbup/install | bash
+export PATH="$HOME/.bbup/bin:$PATH"
+bbup
+
+echo "\n--- Compiling all Noir circuits ---"
+find . -name 'Nargo.toml' | while read -r nargo_toml; do
+  dir=$(dirname "$nargo_toml")
+  echo "Compiling Noir circuit in $dir"
+  (cd "$dir" && nargo compile || echo "Failed to compile in $dir")
+done
+
+echo "\n--- Installing Node.js dependencies ---"
+find . -name 'package.json' | while read -r pkg; do
+  dir=$(dirname "$pkg")
+  if [ -f "$dir/package-lock.json" ] || [ -f "$dir/yarn.lock" ]; then
+    echo "Installing Node.js deps in $dir"
+    (cd "$dir" && (npm install || yarn install) || echo "Failed to install Node.js deps in $dir")
+  else
+    echo "Installing Node.js deps in $dir"
+    (cd "$dir" && npm install || echo "Failed to install Node.js deps in $dir")
+  fi
+done
+
+echo "\n--- Installing Rust dependencies ---"
+find . -name 'Cargo.toml' | while read -r cargo; do
+  dir=$(dirname "$cargo")
+  echo "Building Rust project in $dir"
+  (cd "$dir" && cargo build || echo "Failed to build Rust project in $dir")
+done
+
+echo "\nAll done!" 


### PR DESCRIPTION
Remove target and node_modules from cursorignore; add setup-all.sh script for installing Noir, Barretenberg, and dependencies

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
