### PR TITLE
Add ternary_condition example to noir_by_example

### DIFF
--- a/noir_by_example/ternary_condition/README.md
+++ b/noir_by_example/ternary_condition/README.md
@@ -1,0 +1,23 @@
+# Ternary Condition — Noir vs Rust
+
+This example demonstrates conditional logic in Noir and Rust — specifically, selecting between two values based on a boolean condition. It illustrates how ternary-like behavior (`condition ? x : y`) is written in both languages.
+
+
+## 🔍 Description
+
+Given two values `x` and `y`, and a boolean `condition`, the circuit or function returns `x` if the condition is true, and `y` otherwise.
+
+## 📂 Files
+
+- `src/main.nr` – Noir implementation
+- `src/main.rs` – Rust equivalent
+## 🧠 Purpose
+
+- Highlights **conditional branching** based on a public input.
+- Illustrates the parallel between **Noir’s `if`/`else`** and **Rust’s ternary-like behavior**.
+- Useful in **zero-knowledge circuits** for selecting values without leaking control flow.
+
+## ✅ When to Use
+
+- When you want a **branchless selection** in circuits.
+- For **simple logic choices** in Rust or ZK applications.

--- a/noir_by_example/ternary_condition/noir/Nargo.toml
+++ b/noir_by_example/ternary_condition/noir/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ternary_condition"
+type = "bin"
+authors = [""]
+
+compiler_version = ">=1.0.0"
+
+[dependencies]

--- a/noir_by_example/ternary_condition/noir/Prover.toml
+++ b/noir_by_example/ternary_condition/noir/Prover.toml
@@ -1,0 +1,3 @@
+x = "10"
+y = "20"
+condition = true

--- a/noir_by_example/ternary_condition/noir/src/main.nr
+++ b/noir_by_example/ternary_condition/noir/src/main.nr
@@ -1,0 +1,19 @@
+fn main(x: pub Field, y: pub Field, condition: pub bool) -> pub Field {
+    if condition {
+        x
+    } else {
+        y
+    }
+}
+
+#[test]
+fn test_select_x() {
+    let result = main(10, 20, true);
+    assert(result == 10);
+}
+
+#[test]
+fn test_select_y() {
+    let result = main(10, 20, false);
+    assert(result == 20);
+}

--- a/noir_by_example/ternary_condition/rust/Cargo.toml
+++ b/noir_by_example/ternary_condition/rust/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ternary_condition"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/noir_by_example/ternary_condition/rust/src/main.rs
+++ b/noir_by_example/ternary_condition/rust/src/main.rs
@@ -1,0 +1,18 @@
+fn main() {
+    println!("Selected: {}", select(10, 20, true));  // prints 10
+    println!("Selected: {}", select(10, 20, false)); // prints 20
+}
+
+fn select(x: u32, y: u32, condition: bool) -> u32 {
+    if condition { x } else { y }
+}
+
+#[test]
+fn test_select_x() {
+    assert_eq!(select(10, 20, true), 10);
+}
+
+#[test]
+fn test_select_y() {
+    assert_eq!(select(10, 20, false), 20);
+}


### PR DESCRIPTION
Hi @critesjosh . 👋 — this PR adds a new ternary_condition example to the noir_by_example section.
It demonstrates conditional selection in Noir and Rust, and how such logic can be used safely in zero-knowledge circuits.

Would appreciate a review when you have a moment — thanks! 🙏

# Description

Add `ternary_condition` Noir vs Rust example to the `noir_by_example` directory.

## Problem

Resolves: No specific GitHub issue; this is a new educational addition to the `noir_by_example` examples.

## Summary

This example demonstrates how to perform a ternary-like selection in both Noir and Rust. It's useful in ZK circuits for safely choosing between two values based on a public boolean input.

## Additional Context

- Highlights control flow in circuits without leaking private data
- Mirrors typical conditional logic from Rust for ease of understanding


# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
