### PR TITLE
Add threshold_comparison Noir vs Rust example

### DIFF
--- a/noir_by_example/Cargo.toml
+++ b/noir_by_example/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "simple_macros/rust",
     "loops/rust",
-    "generic_traits/rust"
+    "generic_traits/rust",
+    "threshold_comparison",
 ]
 resolver = "1"

--- a/noir_by_example/Cargo.toml
+++ b/noir_by_example/Cargo.toml
@@ -3,6 +3,6 @@ members = [
     "simple_macros/rust",
     "loops/rust",
     "generic_traits/rust",
-    "threshold_comparison",
+    "threshold_comparison"
 ]
 resolver = "1"

--- a/noir_by_example/Cargo.toml
+++ b/noir_by_example/Cargo.toml
@@ -5,4 +5,4 @@ members = [
     "generic_traits/rust",
     "threshold_comparison"
 ]
-resolver = "1"
+resolver = "2"

--- a/noir_by_example/threshold_comparison/README.md
+++ b/noir_by_example/threshold_comparison/README.md
@@ -1,0 +1,15 @@
+# `threshold_comparison` – Noir vs Rust
+
+## 🧠 Purpose
+
+This example demonstrates conditional logic in a privacy-preserving circuit, showing how to check whether a secret input meets a public threshold and return a public signal.
+
+It highlights:
+
+- How private inputs can be compared to public thresholds without leaking information.
+- How to perform similar logic in Rust for testing or client-side logic.
+
+## ✅ When to Use
+
+- When designing threshold checks in zero-knowledge applications (e.g., age verification, credit checks, score thresholds).
+- When you want to publicly reveal a boolean outcome (`flag`) without leaking private data like the input value.

--- a/noir_by_example/threshold_comparison/noir/Nargo.toml
+++ b/noir_by_example/threshold_comparison/noir/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "threshold_comparison"
+type = "bin"
+authors = [""]
+
+compiler_version = ">=1.0.0"
+
+[dependencies]

--- a/noir_by_example/threshold_comparison/noir/Prover.toml
+++ b/noir_by_example/threshold_comparison/noir/Prover.toml
@@ -1,0 +1,3 @@
+input = 42
+threshold = 30
+flag = 1

--- a/noir_by_example/threshold_comparison/noir/src/main.nr
+++ b/noir_by_example/threshold_comparison/noir/src/main.nr
@@ -1,0 +1,35 @@
+fn main(input: Field, threshold: pub Field, flag: pub Field) {
+    let input_u32 = input as u32;
+    let threshold_u32 = threshold as u32;
+    let is_valid = if input_u32 >= threshold_u32 { 1 } else { 0 };
+    assert(is_valid == flag);
+}
+
+#[test]
+fn test_input_meets_threshold() {
+    let input = 21;
+    let threshold = 18;
+    let flag = 1; // Should pass: 21 >= 18
+    let is_valid = if input >= threshold { 1 } else { 0 };
+    assert(is_valid == flag);
+}
+
+#[test]
+fn test_input_below_threshold() {
+    let input = 16;
+    let threshold = 18;
+    let flag = 0; // Should pass: 16 < 18
+    let is_valid = if input >= threshold { 1 } else { 0 };
+    assert(is_valid == flag);
+}
+
+// Optional failing test for demonstration purposes:
+// #[test]
+// fn test_invalid_flag() {
+//     let input = 17;
+//     let threshold = 18;
+//     let flag = 1; // Incorrect: should be 0
+//     let is_valid = if input >= threshold { 1 } else { 0 };
+//     assert(is_valid == flag); // This will fail
+// }
+

--- a/noir_by_example/threshold_comparison/rust/Cargo.toml
+++ b/noir_by_example/threshold_comparison/rust/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "threshold_comparison"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/noir_by_example/threshold_comparison/rust/src/main.rs
+++ b/noir_by_example/threshold_comparison/rust/src/main.rs
@@ -1,0 +1,19 @@
+fn threshold_check(input: u32, threshold: u32, flag: u32) {
+    let is_valid = if input >= threshold { 1 } else { 0 };
+    assert_eq!(is_valid, flag);
+}
+
+fn main() {
+    threshold_check(22, 18, 1);
+}
+
+#[test]
+fn test_input_above_threshold() {
+    threshold_check(30, 18, 1);
+}
+
+#[test]
+fn test_input_below_threshold() {
+    threshold_check(10, 18, 0);
+}
+


### PR DESCRIPTION


Hi @critesjosh 👋,

This PR adds a new Noir vs Rust example: threshold_comparison, which demonstrates how to compare a secret input against a public threshold and output a public flag. It's useful for modeling zero-knowledge scenarios like age checks or score thresholds.

I'd appreciate your review and any feedback on improvements or consistency with existing examples. Thanks!

# Description

Add `threshold_comparison` Noir vs Rust example to the `noir_by_example` directory.

## Problem

Resolves: No specific GitHub issue; this is a new educational addition to the `noir_by_example` examples.

## Summary

This example demonstrates how to implement a conditional comparison between a secret input and a public threshold, outputting a public flag.

- Noir circuit compares a private input (e.g., age, score) to a public threshold.
- Rust version mirrors the logic for familiarity and testability.

## Additional Context

🧠 **Purpose**
- Demonstrates privacy-preserving conditional logic.
- Shows how to safely reveal a boolean flag without leaking private input.

✅ **When to Use**
- For building ZK circuits involving public eligibility criteria (e.g., age ≥ 18).
- Whenever you want to expose just the comparison result while hiding the value being compared.



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
