### PR TITLE
Verify two different proofs. WIP

### DIFF
--- a/recursion/circuits/recursive/src/main.nr
+++ b/recursion/circuits/recursive/src/main.nr
@@ -3,14 +3,24 @@ global HONK_PROOF_SIZE: u32 = 456;
 global HONK_IDENTIFIER: u32 = 1;
 
 fn main(
-    verification_key: [Field; HONK_VK_SIZE],
-    proof: [Field; HONK_PROOF_SIZE],
-    public_inputs: pub [Field; 1],
+    verification_key1: [Field; HONK_VK_SIZE],
+    proof1: [Field; HONK_PROOF_SIZE],
+    public_inputs1: pub [Field; 1],
+    verification_key2: [Field; HONK_VK_SIZE],
+    proof2: [Field; HONK_PROOF_SIZE],
+    public_inputs2: pub [Field; 1],
 ) {
     std::verify_proof_with_type(
-        verification_key,
-        proof,
-        public_inputs,
+        verification_key1,
+        proof1,
+        public_inputs1,
+        0x0,
+        HONK_IDENTIFIER,
+    );
+    std::verify_proof_with_type(
+        verification_key2,
+        proof2,
+        public_inputs2,
         0x0,
         HONK_IDENTIFIER,
     );

--- a/recursion/js/generate-proof.ts
+++ b/recursion/js/generate-proof.ts
@@ -8,28 +8,44 @@ import { CompiledCircuit, Noir } from "@noir-lang/noir_js";
     const innerCircuitNoir = new Noir(innerCircuit as CompiledCircuit);
     const innerBackend = new UltraHonkBackend(innerCircuit.bytecode, { threads: 1 }, { recursive: true });
 
-    // Generate proof for inner circuit
-    const inputs = { x: 3, y: 3 }
-    const { witness } = await innerCircuitNoir.execute(inputs);
-    const { proof: innerProofFields, publicInputs: innerPublicInputs } = await innerBackend.generateProofForRecursiveAggregation(witness);
+    // Generate proof for inner circuit1
+    const inputs1 = { x: 3, y: 3 }
+    const { witness: witness1 } = await innerCircuitNoir.execute(inputs1);
+    const { proof: innerProofFields1, publicInputs: innerPublicInputs1 } = await innerBackend.generateProofForRecursiveAggregation(witness1);
 
-    // Get verification key for inner circuit as fields
-    const innerCircuitVerificationKey = await innerBackend.getVerificationKey();
+    // Get verification key for inner circuit1 as fields
+    const innerCircuitVerificationKey1 = await innerBackend.getVerificationKey();
     const barretenbergAPI = await Barretenberg.new({ threads: 1 });
-    const vkAsFields = (await barretenbergAPI.acirVkAsFieldsUltraHonk(new RawBuffer(innerCircuitVerificationKey))).map(field => field.toString());
+    const vkAsFields1 = (await barretenbergAPI.acirVkAsFieldsUltraHonk(new RawBuffer(innerCircuitVerificationKey1))).map(field => field.toString());
+
+    // Generate proof for inner circuit2
+    const inputs2 = { x: 2, y: 5 }
+    const { witness: witness2 } = await innerCircuitNoir.execute(inputs2);
+    const { proof: innerProofFields2, publicInputs: innerPublicInputs2 } = await innerBackend.generateProofForRecursiveAggregation(witness2);
+
+    // Get verification key for inner circuit2 as fields
+    const innerCircuitVerificationKey2 = await innerBackend.getVerificationKey();
+    const vkAsFields2 = (await barretenbergAPI.acirVkAsFieldsUltraHonk(new RawBuffer(innerCircuitVerificationKey2))).map(field => field.toString());
 
     // Generate proof of the recursive circuit
     const recursiveCircuitNoir = new Noir(recursiveCircuit as CompiledCircuit);
     const recursiveBackend = new UltraHonkBackend(recursiveCircuit.bytecode, { threads: 1 });
 
-    const recursiveInputs = { proof: innerProofFields, public_inputs: innerPublicInputs, verification_key: vkAsFields };
+    const recursiveInputs = {
+      proof1: innerProofFields1,
+      public_inputs1: innerPublicInputs1,
+      verification_key1: vkAsFields1,
+      proof2: innerProofFields2,
+      public_inputs2: innerPublicInputs2,
+      verification_key2: vkAsFields2,
+    };
     const { witness: recursiveWitness } = await recursiveCircuitNoir.execute(recursiveInputs);
     const { proof: recursiveProof, publicInputs: recursivePublicInputs } = await recursiveBackend.generateProof(recursiveWitness);
 
     // Verify recursive proof
     const verified = await recursiveBackend.verifyProof({ proof: recursiveProof, publicInputs: recursivePublicInputs });
     console.log("Recursive proof verified: ", verified);
-    
+
     process.exit(verified ? 0 : 1);
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
# Description

## Problem\*

Double recursion is useful for thinks like proving hashes up a tree.

## Summary\*

Example of double verification in one circuit, but cannot generate proof.

## Additional Context

```
$ tsx ./generate-proof.ts
Error [RuntimeError]: unreachable
    at wasm://wasm/031c2f9e:wasm-function[20245]:0xbe32f0
    at wasm://wasm/031c2f9e:wasm-function[1457]:0x77d40
    at wasm://wasm/031c2f9e:wasm-function[1460]:0x77ec4
    at wasm://wasm/031c2f9e:wasm-function[9456]:0x2ff615
    at wasm://wasm/031c2f9e:wasm-function[812]:0x48896
    at wasm://wasm/031c2f9e:wasm-function[806]:0x4881b
    at wasm://wasm/031c2f9e:wasm-function[803]:0x487cd
    at wasm://wasm/031c2f9e:wasm-function[139]:0x280ce
    at wasm://wasm/031c2f9e:wasm-function[102]:0x25e63
    at wasm://wasm/031c2f9e:wasm-function[18356]:0xb46106
error Command failed with exit code 1.
```

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
