### PR TITLE
install bbup from `next` instead of `master`

### DIFF
--- a/.github/workflows/recursion.yml
+++ b/.github/workflows/recursion.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install bb
         run: |
-          curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/master/barretenberg/bbup/install | bash
+          curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash
           echo "PATH=$PATH:/home/runner/.bb" >> $GITHUB_ENV
 
       - name: Run bbup

--- a/.github/workflows/solidity-example.yml
+++ b/.github/workflows/solidity-example.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install bb
         run: |
-          curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/master/barretenberg/bbup/install | bash 
+          curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash
           echo "PATH=$PATH:/home/runner/.bb" >> $GITHUB_ENV
 
       - name: Run bbup

--- a/.github/workflows/web-starter-playwright.yml
+++ b/.github/workflows/web-starter-playwright.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install bb
         run: |
-          curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/master/barretenberg/bbup/install | bash
+          curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash
           echo "PATH=$PATH:/home/runner/.bb" >> $GITHUB_ENV
 
       - name: Run bbup


### PR DESCRIPTION
# Description

install bbup from `next` instead of `master`

## Problem\*

It is currently installing from master, which is not the latest branch

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
